### PR TITLE
adding digest package as dependancy

### DIFF
--- a/package.js
+++ b/package.js
@@ -64,7 +64,8 @@ var CORE = [
 
 Package.on_use(function (api) {
   api.use(['coffeescript', 'underscore'], 'server');
-
+  api.use('digest', 'client');
+  api.imply('digest');
   api.export('PDFJS');
 
   api.add_files([


### PR DESCRIPTION
We're adding sha256 support to pdf.js core, so pdf.js should depend on digest package.
